### PR TITLE
Add search paths for macOS Catalina

### DIFF
--- a/Assets/Klak/NDI/Editor/PbxModifier.cs
+++ b/Assets/Klak/NDI/Editor/PbxModifier.cs
@@ -29,6 +29,9 @@ namespace Klak.NdiLite
                 proj.AddBuildProperty(target, "HEADER_SEARCH_PATHS", "/NewTek\\ NDI\\ SDK/include");
                 proj.AddBuildProperty(target, "LIBRARY_SEARCH_PATHS", "/NewTek\\ NDI\\ SDK/lib/iOS");
 
+                proj.AddBuildProperty(target, "HEADER_SEARCH_PATHS", "/Library/NDI\\ SDK\\ for\\ Apple/include");
+                proj.AddBuildProperty(target, "LIBRARY_SEARCH_PATHS", "/Library/NDI\\ SDK\\ for\\ Apple/lib/iOS");
+
                 // Add the NDI library to the build phase.
                 proj.AddFrameworkToProject(target, "libndi_ios.a", false);
 


### PR DESCRIPTION
To fix #43, Added extra search paths of the default SDK install location of macOS Catalina.