### PR TITLE
Exclude non-supported platforms

### DIFF
--- a/jp.keijiro.klak.ndi/Runtime/Klak.Ndi.Runtime.asmdef
+++ b/jp.keijiro.klak.ndi/Runtime/Klak.Ndi.Runtime.asmdef
@@ -4,7 +4,14 @@
     "references": [
         "GUID:df380645f10b7bc4b97d4f5eb6303d95"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "iOS",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,


### PR DESCRIPTION
Adjusted the runtime assembly definition to only include the supported platforms listed on the README by default