### PR TITLE
Apply vertical flip to screen shot image when graphics device type is equal to OpenGL series.

### DIFF
--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiSender.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiSender.cs
@@ -89,7 +89,15 @@ public sealed partial class NdiSender : MonoBehaviour
                 ScreenCapture.CaptureScreenshotIntoRenderTexture(tempRT);
 
                 // Pixel format conversion
-                var buffer = _converter.Encode(tempRT, keepAlpha, false);
+                bool vflip = false;
+                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3)
+                {
+                    vflip = true;
+                }
+                
+                var buffer = _converter.Encode(tempRT, keepAlpha, vflip);
                 RenderTexture.ReleaseTemporary(tempRT);
 
                 // Readback entry allocation and request


### PR DESCRIPTION
When the graphics backend is OpenGL, the image obtained with "ScreenCapture.CaptureScreenshotIntoRenderTexture" is vertically flipped compared to other graphics backends.
It seems to be that because of the OpenGL coordinate system is different from it of other graphics backends.
I solved this issue by adding a process that determines if the graphics backend is OpenGL and flips vertically after capturing the GameView.

■ Screen shot: before fix
<img width="1630" alt="Before_Fix" src="https://user-images.githubusercontent.com/2960956/188894859-760153b4-3cbb-4106-bf23-d5ddbb091311.PNG">

■ Screen shot: after fix.
<img width="1653" alt="After_Fix" src="https://user-images.githubusercontent.com/2960956/188894873-a14a48da-4f89-45c8-aa6a-2beb83c239fa.PNG">
