### PR TITLE
Update AndroidHelper.cs for new Unity API

### DIFF
--- a/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
@@ -13,15 +13,22 @@ static class AndroidHelper
 
     public static void SetupNetwork()
     {
-        // Enable multicasting: This also adds the network permissions to the
-        // application manifest.
-        NetworkTransport.SetMulticastLock(true);
-
         // Create a network service discovery manager object.
         var player = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
         var activity = player.GetStatic<AndroidJavaObject>("currentActivity");
         _nsdManager = activity.Call<AndroidJavaObject>
           ("getSystemService", "servicediscovery");
+
+        // Enable multicasting:
+        var wifiManager = activity.Call<AndroidJavaObject>("getSystemService", "wifi");
+            // Check if the multicast lock is active.
+            var lockActive = wifiManager.Call<AndroidJavaObject>("createMulticastLock", "klak-ndi").Call<bool>("isHeld");
+
+            // If not, acquire the lock.
+            if (!lockActive)
+            {
+                wifiManager.Call<AndroidJavaObject>("createMulticastLock", "klak-ndi").Call("acquire");
+            }
     }
 
     #else


### PR DESCRIPTION
Set multicast lock without calling deprecated/removed Unity APIs

This should resolve #167 