### PR TITLE
Android target level 32 support

### DIFF
--- a/jp.keijiro.klak.ndi/Plugin/Android/DiscoveryListener.java
+++ b/jp.keijiro.klak.ndi/Plugin/Android/DiscoveryListener.java
@@ -1,0 +1,13 @@
+package jp.keijiro.klak.ndi;
+
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+
+public class DiscoveryListener implements NsdManager.DiscoveryListener {
+    public void onDiscoveryStarted(String str) {}
+    public void onDiscoveryStopped(String str) {}
+    public void onStartDiscoveryFailed(String str, int i) {}
+    public void onStopDiscoveryFailed(String str, int i) {}
+    public void onServiceFound(NsdServiceInfo nsdServiceInfo) {}
+    public void onServiceLost(NsdServiceInfo nsdServiceInfo) {}
+}

--- a/jp.keijiro.klak.ndi/Plugin/Android/DiscoveryListener.java.meta
+++ b/jp.keijiro.klak.ndi/Plugin/Android/DiscoveryListener.java.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 714498779e26bb6469aad20bb23e4a72
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
@@ -22,12 +22,20 @@ static class AndroidHelper
         var activity = player.GetStatic<AndroidJavaObject>("currentActivity");
         _nsdManager = activity.Call<AndroidJavaObject>
           ("getSystemService", "servicediscovery");
-          
+
+        // Get applicationInfo and targetSdkVersion from activity.
+        var context = activity.Call<AndroidJavaObject>("getApplicationContext");
+        var info = context.Call<AndroidJavaObject>("getApplicationInfo");
+        var targetSdkVersion = info.Get<int>("targetSdkVersion");
+        
         // Start service discovery for NDI TCP and UDP services. Android API Level 31+ doesn't do that automatically anymore when calling `getSystemService`.
-        var tcpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
-        var udpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
-        _nsdManager.Call("discoverServices", "_ndi._tcp", 1, tcpListener);
-        _nsdManager.Call("discoverServices", "_ndi._udp", 1, udpListener);
+        if (targetSdkVersion >= 31)
+        {
+            var tcpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
+            var udpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
+            _nsdManager.Call("discoverServices", "_ndi._tcp", 1, tcpListener);
+            _nsdManager.Call("discoverServices", "_ndi._udp", 1, udpListener);
+        }
     }
 
     #else

--- a/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Internal/AndroidHelper.cs
@@ -22,6 +22,12 @@ static class AndroidHelper
         var activity = player.GetStatic<AndroidJavaObject>("currentActivity");
         _nsdManager = activity.Call<AndroidJavaObject>
           ("getSystemService", "servicediscovery");
+          
+        // Start service discovery for NDI TCP and UDP services. Android API Level 31+ doesn't do that automatically anymore when calling `getSystemService`.
+        var tcpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
+        var udpListener = new AndroidJavaObject("jp.keijiro.klak.ndi.DiscoveryListener");
+        _nsdManager.Call("discoverServices", "_ndi._tcp", 1, tcpListener);
+        _nsdManager.Call("discoverServices", "_ndi._udp", 1, udpListener);
     }
 
     #else


### PR DESCRIPTION
This PR fixes #190 and potentially also #166.

It adds a minimal .java plugin with a discovery listener and calls NsdManager.discoverServices for the NDI-specific UDP and TCP services on Android >= 31.