### PR TITLE
Introduce a new property 'ndiFPS' in NdiSender for controlling the sending rate

### DIFF
--- a/jp.keijiro.klak.ndi/Editor/NdiSenderEditor.cs
+++ b/jp.keijiro.klak.ndi/Editor/NdiSenderEditor.cs
@@ -16,6 +16,7 @@ sealed class NdiSenderEditor : UnityEditor.Editor
 
     AutoProperty _ndiName;
     AutoProperty _keepAlpha;
+    AutoProperty _ndiFPS;
     AutoProperty _captureMethod;
     AutoProperty _sourceCamera;
     AutoProperty _sourceTexture;
@@ -35,6 +36,9 @@ sealed class NdiSenderEditor : UnityEditor.Editor
 
         // Keep Alpha
         EditorGUILayout.PropertyField(_keepAlpha);
+
+        // FPS
+        EditorGUILayout.PropertyField(_ndiFPS);
 
         // Capture Method
         EditorGUILayout.PropertyField(_captureMethod);

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiSender_Properties.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiSender_Properties.cs
@@ -28,6 +28,15 @@ public sealed partial class NdiSender : MonoBehaviour
       { get => _keepAlpha;
         set => _keepAlpha = value; }
 
+    [SerializeField, Tooltip("Control sending rate, 0 means no limit")]
+    int _ndiFPS = 30;
+
+    public int ndiFPS
+    {
+      get => _ndiFPS;
+      set => _ndiFPS = value;
+    }
+
     #endregion
 
     #region Capture target settings


### PR DESCRIPTION
Sending too fast eats up a lot of bandwidth, making the receiver laggy and choppy. This enhancement allows users to control the sending rate as needed.