### PR TITLE
Feature: Frame Rate Options for Sender

### DIFF
--- a/jp.keijiro.klak.ndi/Editor/NdiSenderEditor.cs
+++ b/jp.keijiro.klak.ndi/Editor/NdiSenderEditor.cs
@@ -19,6 +19,8 @@ sealed class NdiSenderEditor : UnityEditor.Editor
     AutoProperty _captureMethod;
     AutoProperty _sourceCamera;
     AutoProperty _sourceTexture;
+    private AutoProperty setRenderTargetFrameRate;
+    private AutoProperty frameRate;
 
     #pragma warning restore
 
@@ -51,6 +53,9 @@ sealed class NdiSenderEditor : UnityEditor.Editor
             _captureMethod.Target.enumValueIndex == (int)CaptureMethod.Texture)
             EditorGUILayout.PropertyField(_sourceTexture);
 
+        EditorGUILayout.PropertyField(frameRate);
+        EditorGUILayout.PropertyField(setRenderTargetFrameRate);
+        
         EditorGUI.indentLevel--;
 
         serializedObject.ApplyModifiedProperties();

--- a/jp.keijiro.klak.ndi/Runtime/Component/FrameRateOptions.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/FrameRateOptions.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Klak.Ndi
+{
+    public enum FrameRateOptions
+    {
+        Standard_NTSC_24,
+        Standard_NTSC_29_97,
+        Standard_NTSC_59_94,
+        Standard_PAL_25,
+        Standard_PAL_50,
+        Common_30,
+        Common_60
+    }
+
+    public static class FrameRateOptionExt
+    {
+        public static void GetND(this FrameRateOptions opt, out int n, out int d)
+        {
+            switch (opt)
+            {
+                case FrameRateOptions.Standard_NTSC_24:
+                    n = 24000;
+                    d = 1001;
+                    break;
+                case FrameRateOptions.Standard_NTSC_29_97:
+                    n = 30000;
+                    d = 1001;
+                    break;
+                case FrameRateOptions.Standard_NTSC_59_94:
+                    n = 60000;
+                    d = 1001;
+                    break;
+                case FrameRateOptions.Standard_PAL_25:
+                    n = 30000;
+                    d = 1200;
+                    break;
+                case FrameRateOptions.Standard_PAL_50:
+                    n = 60000;
+                    d = 1200;
+                    break;
+                case FrameRateOptions.Common_30:
+                    n = 30000;
+                    d = 1000;
+                    break;
+                case FrameRateOptions.Common_60:
+                    n = 60000;
+                    d = 1000;
+                    break;
+                default:
+                    throw new NotImplementedException("Not implemented " + nameof(opt), null);
+            }
+        }
+
+        public static int GetUnityFrameTarget(this FrameRateOptions opt)
+        {
+            switch (opt)
+            {
+                case FrameRateOptions.Standard_NTSC_24:
+                    return 24;
+                case FrameRateOptions.Standard_NTSC_29_97:
+                    return 30;
+                case FrameRateOptions.Standard_NTSC_59_94:
+                    return 60;
+                case FrameRateOptions.Standard_PAL_25:
+                    return 25;
+                case FrameRateOptions.Standard_PAL_50:
+                    return 50;
+                case FrameRateOptions.Common_30:
+                    return 30;
+                case FrameRateOptions.Common_60:
+                    return 60;
+                default:
+                    throw new NotImplementedException("Not implemented " + nameof(opt), null);
+            }
+        }
+    }
+}

--- a/jp.keijiro.klak.ndi/Runtime/Component/FrameRateOptions.cs.meta
+++ b/jp.keijiro.klak.ndi/Runtime/Component/FrameRateOptions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7af5b5f11734a50ac0a307fea773f52
+timeCreated: 1721202635

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiSender.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiSender.cs
@@ -55,6 +55,13 @@ public sealed partial class NdiSender : MonoBehaviour
     }
 
     #endregion
+    
+    private void Update()
+    {
+        int targetFrameRate = setRenderTargetFrameRate ? frameRate.GetUnityFrameTarget() : -1;
+        if (Application.targetFrameRate != targetFrameRate)
+            Application.targetFrameRate = targetFrameRate;
+    }
 
     #region Capture coroutine for the Texture/GameView capture methods
 
@@ -146,6 +153,8 @@ public sealed partial class NdiSender : MonoBehaviour
             return;
         }
 
+        frameRate.GetND(out var frameRateN, out var frameRateD);
+        
         // Frame data
         var frame = new Interop.VideoFrame
           { Width       = entry.Width,
@@ -153,8 +162,11 @@ public sealed partial class NdiSender : MonoBehaviour
             LineStride  = entry.Stride,
             FourCC      = entry.FourCC,
             FrameFormat = Interop.FrameFormat.Progressive,
-            Data        = entry.ImagePointer,
-            Metadata    = entry.MetadataPointer };
+            Data = entry.ImagePointer,
+            Metadata = entry.MetadataPointer,
+            FrameRateD = frameRateD,
+            FrameRateN = frameRateN
+        };
 
         // Async-send initiation
         // This causes a synchronization for the last frame -- i.e., It locks

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiSender_Properties.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiSender_Properties.cs
@@ -66,6 +66,9 @@ public sealed partial class NdiSender : MonoBehaviour
       { get => _sourceTexture;
         set => _sourceTexture = value; }
 
+    public FrameRateOptions frameRate = FrameRateOptions.Common_60;
+    public bool setRenderTargetFrameRate = false;
+
     #endregion
 
     #region Runtime property


### PR DESCRIPTION
Added some basic frame rate options as an Enum: (for VideoFrame Framerate)
        Standard_NTSC_24 > 24 fps
        Standard_NTSC_29_97 > 29.97 fps
        Standard_NTSC_59_94 > 59.94 fps
        Standard_PAL_25, > 25 fps
        Standard_PAL_50 > 50 fps
        Common_30 > 30 fps
        Common_60 > 60 fps

Also added the option to set the application target frame rate based on the selected frame rate settings. 
This should help for a more consistent relation between NDI framerate and render frame rate.


