### PR TITLE
NdiReceiver: expose videoframe info

### DIFF
--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
@@ -1,4 +1,4 @@
-﻿using Unity.Collections.LowLevel.Unsafe;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using IntPtr = System.IntPtr;
 using Marshal = System.Runtime.InteropServices.Marshal;
@@ -49,6 +49,14 @@ public sealed partial class NdiReceiver : MonoBehaviour
         // Pixel format conversion
         var rt = _converter.Decode
           (frame.Width, frame.Height, Util.HasAlpha(frame.FourCC), frame.Data);
+
+        // Store the frame information
+        _resolution.Set(frame.Width, frame.Height);
+        _aspectRatio = frame.AspectRatio;
+        _frameRateN = frame.FrameRateN;
+        _frameRateD = frame.FrameRateD;
+        _timecode = frame.Timecode;
+        _timestamp = frame.Timestamp;
 
         // Metadata retrieval
         if (frame.Metadata != IntPtr.Zero)

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
@@ -50,6 +50,33 @@ public sealed partial class NdiReceiver : MonoBehaviour
 
     public string metadata { get; set; }
 
+    private Vector2Int _resolution = new Vector2Int();
+    private float _aspectRatio = 0;
+    private int _frameRateD = 0;
+    private int _frameRateN = 0;
+    private long _timecode = 0;
+    private long _timestamp = 0;
+
+    // Pixel resolution
+    public Vector2Int resolution { get => _resolution; }
+
+    // picture aspect ratio (width/height)
+    // This may be different to resolution.x / resolution.y if the pixels are not square
+    public float aspectRatio { get => _aspectRatio; }
+
+    public float frameRate
+      { get
+        {
+          if (_frameRateD == 0) return 0;
+          return _frameRateN / _frameRateD;
+        }
+      }
+
+    // Frame Timecode in 100ns (trivially convertible to DateTime)
+    public long timecode { get => _timecode; }
+    // Timestamp when frame was submitted by the sender (100ns)
+    public long timestamp { get => _timestamp; }
+
     public Interop.Recv internalRecvObject => _recv;
 
     #endregion


### PR DESCRIPTION
For each successfully received frame, store:
- resolution
- aspect ratio
- framerate
- timecode
- timestamp

Closes Issue #209 