### PR TITLE
Invoke an Event on receiving a frame with an unsupported resolution

### DIFF
--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
@@ -46,6 +46,14 @@ public sealed partial class NdiReceiver : MonoBehaviour
         if (frameOrNull == null) return null;
         var frame = (Interop.VideoFrame)frameOrNull;
 
+        // Store the frame information
+        _resolution.Set(frame.Width, frame.Height);
+        _aspectRatio = frame.AspectRatio;
+        _frameRateN = frame.FrameRateN;
+        _frameRateD = frame.FrameRateD;
+        _timecode = frame.Timecode;
+        _timestamp = frame.Timestamp;
+
         // Verify that the frame is supported
         if ((frame.Width & 0xf) != 0)
         {
@@ -70,14 +78,6 @@ public sealed partial class NdiReceiver : MonoBehaviour
         // Pixel format conversion
         var rt = _converter.Decode
           (frame.Width, frame.Height, Util.HasAlpha(frame.FourCC), frame.Data);
-
-        // Store the frame information
-        _resolution.Set(frame.Width, frame.Height);
-        _aspectRatio = frame.AspectRatio;
-        _frameRateN = frame.FrameRateN;
-        _frameRateD = frame.FrameRateD;
-        _timecode = frame.Timecode;
-        _timestamp = frame.Timestamp;
 
         // Metadata retrieval
         if (frame.Metadata != IntPtr.Zero)

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
@@ -1,4 +1,4 @@
-﻿using Unity.Collections.LowLevel.Unsafe;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using IntPtr = System.IntPtr;
 using Marshal = System.Runtime.InteropServices.Marshal;
@@ -49,6 +49,14 @@ public sealed partial class NdiReceiver : MonoBehaviour
         // Pixel format conversion
         var rt = _converter.Decode
           (frame.Width, frame.Height, Util.HasAlpha(frame.FourCC), frame.Data);
+
+        // Store the frame information
+        _resolution.Set(frame.Width, frame.Height);
+        _aspectRatio = frame.AspectRatio;
+        _frameRateN = frame.FrameRateN;
+        _frameRateD = frame.FrameRateD;
+        _timecode = frame.Timecode;
+        _timestamp = frame.Timestamp;
 
         // Metadata retrieval
         if (frame.Metadata != IntPtr.Zero)

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver.cs
@@ -46,6 +46,27 @@ public sealed partial class NdiReceiver : MonoBehaviour
         if (frameOrNull == null) return null;
         var frame = (Interop.VideoFrame)frameOrNull;
 
+        // Verify that the frame is supported
+        if ((frame.Width & 0xf) != 0)
+        {
+            string text = new($"Width ({frame.Width}) must be a multiple of 16.");
+            if (UnsupportedStreamEvent != null)
+                UnsupportedStreamEvent.Invoke(this, new UnsupportedStreamEventArgs(text, _resolution));
+            else
+                Debug.LogWarning("[KlakNDI] Unsupported frame size: " + text);
+            return null;
+        }
+
+        if ((frame.Height & 0x7) != 0)
+        {
+            string text = new($"Height ({frame.Height}) must be a multiple of 8.");
+            if (UnsupportedStreamEvent != null)
+                UnsupportedStreamEvent.Invoke(this, new UnsupportedStreamEventArgs(text, _resolution));
+            else
+                Debug.LogWarning("[KlakNDI] Unsupported frame size: " + text);
+            return null;
+        }
+
         // Pixel format conversion
         var rt = _converter.Decode
           (frame.Width, frame.Height, Util.HasAlpha(frame.FourCC), frame.Data);

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
@@ -50,6 +50,33 @@ public sealed partial class NdiReceiver : MonoBehaviour
 
     public string metadata { get; set; }
 
+    private Vector2Int _resolution = new Vector2Int();
+    private float _aspectRatio = 0;
+    private int _frameRateD = 0;
+    private int _frameRateN = 0;
+    private long _timecode = 0;
+    private long _timestamp = 0;
+
+    // Pixel resolution
+    public Vector2Int resolution { get => _resolution; }
+
+    // picture aspect ratio (width/height)
+    // This may be different to resolution.x / resolution.y if the pixels are not square
+    public float aspectRatio { get => _aspectRatio; }
+
+    public float frameRate
+      { get
+        {
+          if (_frameRateD == 0) return 0;
+          return _frameRateN / _frameRateD;
+        }
+      }
+
+    // Frame Timecode in 100ns (trivially convertible to DateTime)
+    public long timecode { get => _timecode; }
+    // Timestamp when frame was submitted by the sender (100ns)
+    public long timestamp { get => _timestamp; }
+
     public Interop.Recv internalRecvObject => _recv;
 
     #endregion

--- a/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
+++ b/jp.keijiro.klak.ndi/Runtime/Component/NdiReceiver_Properties.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Klak.Ndi {
@@ -78,6 +79,25 @@ public sealed partial class NdiReceiver : MonoBehaviour
     public long timestamp { get => _timestamp; }
 
     public Interop.Recv internalRecvObject => _recv;
+
+    #endregion
+
+    #region Events
+
+    public class UnsupportedStreamEventArgs : EventArgs
+    {
+      public string warning { get; }
+      public Vector2Int resolution { get; }
+
+      public UnsupportedStreamEventArgs(string warning, Vector2Int resolution)
+      {
+        this.warning = warning;
+        this.resolution = resolution;
+      }
+    }
+
+    public delegate void UnsupportedStreamEventHandler(object sender, UnsupportedStreamEventArgs ev);
+    public event UnsupportedStreamEventHandler UnsupportedStreamEvent;
 
     #endregion
 


### PR DESCRIPTION
Similar to PR #181 

This approach has the NdiReceiver raise the event instead of the FrameConvertor.

The main advantage of this is that it allows the application to draw an alternative frame, such as an error message.

This PR also does not log a warning itself if the event has any subscribers, on the assumption that the host application will handle this as desired.

Note: This is based on PR #232 